### PR TITLE
Fix the Github link

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -57,7 +57,7 @@ export const Footer = ({
           </NavigationSection>
           <NavigationSection>
             <Heading>Developers</Heading>
-            <a href={"https://github.com/dot-brower"}>GitHub</a>
+            <a href={"https://github.com/dot-browser"}>GitHub</a>
             <a href={"/api"}>API</a>
           </NavigationSection>
           <NavigationSection>


### PR DESCRIPTION
Github link currently leads to a 404. 

Just a quick change to make the github link work.